### PR TITLE
Fix "Recode Hive" Text Visibility in Dark Mode on Blog

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -355,6 +355,11 @@ body.dark-mode .navbar-link {
   color: #f0f0f0;
 }
 
+body.dark-mode .navbar-text {
+  background-color: #333;
+  color: #f0f0f0;
+}
+
 body.dark-mode .navbar-link:hover {
   background-color: #555;
 }


### PR DESCRIPTION
fixes #149 

This Pull Request addresses the issue where the "Recode Hive" text in the navigation bar on `blog.html` becomes invisible when dark mode is activated. The text lacks sufficient contrast against the dark background, making it unreadable.

### Changes Made

- Updated CSS to enhance text visibility in dark mode.