### PR TITLE
Made the tables responsive of github-badges page.

### DIFF
--- a/githubbadge.html
+++ b/githubbadge.html
@@ -49,19 +49,21 @@
                 overflow-x: auto;
                 display: block;
             }
-            table, th, td {
+            table {
                 display: block;
                 width: 100%;
+                overflow-x: scroll;
             }
             th, td {
                 box-sizing: border-box;
                 padding: 10px;
+                text-align: center !important;
             }
             td {
                 border: none;
                 border-bottom: 1px solid #ddd;
                 position: relative;
-                padding-left: 50%;
+                /* padding-left: 50%; */
                 text-align: right;
             }
             td::before {


### PR DESCRIPTION
# Fixes #172

# Description:

- Made the tables responsive so that the badges appear clear & it's info as well on mobile view.

# Video:


https://github.com/user-attachments/assets/5fff4f9c-5ef3-470a-97b2-bb3767fb1c4f



_@sanjay-kv sir please review & merge this pr under GSSoC'24_