### PR TITLE
Made the blog page & github badges page responsive

### DIFF
--- a/pages/githubbadge.html
+++ b/pages/githubbadge.html
@@ -231,7 +231,7 @@
   }
 
 
-  @media (max-width: 768px) {
+  @media screen and (max-width: 768px) {
     .navbar-right {
       display: none !important;
     }
@@ -245,6 +245,9 @@
         margin-top: 35px;
     }
 
+    .ways-content {
+        padding: 0 !important;
+    }
   }
   </style>
   <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">

--- a/styles/blog.css
+++ b/styles/blog.css
@@ -5,6 +5,10 @@ body {
     padding: 0;
 }
 
+body img {
+    max-width: 100vw !important;
+}
+
 .blog-container {
     display: flex;
     flex-wrap: wrap;
@@ -106,6 +110,9 @@ body.dark-mode .blog-card .excerpt {
 @media (max-width:768px) {
     .blog-card{
         width: 100%;
+    }
+    .ways-content {
+        padding: 0 !important;
     }
 }
 

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -579,7 +579,7 @@ body.dark-mode .navbar-link:hover {
 }
 
 .footer-logo {
-  max-width: 100%;
+  max-width: 100% !important;
   height: auto;
   cursor: pointer;
 }


### PR DESCRIPTION
# Fixes:  #227 

## Description:

- Made the blog page & github badges page responsive for mobile view.
- Removed the extra blank space from the right side of the web pages.

## Video:


https://github.com/user-attachments/assets/2fb7a82f-557a-4fe0-ac44-a5942e903dd1




@sanjay-kv sir please review & merge my pr under GSSoC'24 