### PR TITLE
Fixed filter box style for dark mode

### DIFF
--- a/styles/styles.css
+++ b/styles/styles.css
@@ -554,10 +554,11 @@ body.dark-mode .toggle-label {
 }
 
 /* Dark mode adjustments */
-body.dark-mode .navbar {
+body.dark-mode .navbar, body.dark-mode .modal-content {
   background-color: #333;
   color: #f0f0f0;
 }
+
 
 body.dark-mode .navbar-link {
   color: #f0f0f0;


### PR DESCRIPTION
# Fixed: #257 

# Description:
- Fixed filter box style for dark mode.
- Now, the filter options will be clearly visible in both light mode & dark mode.


# Video:


https://github.com/user-attachments/assets/fb6ca6a4-86e5-43a6-824b-5bb834c5bd39



@sanjay-kv @dinxsh please review & merge my pull-request under GSSoC'24