### PR TITLE
Fix Text Visibility in Light Mode

### DIFF
--- a/styles/styles.css
+++ b/styles/styles.css
@@ -214,6 +214,10 @@ body.dark-mode .profile p {
   transition: background-color 0.5s ease;
 }
 
+.no-profiles-message h2 {
+  color: black;
+}
+
 /* Styling for Vertical Scrollbar */
 
 ::-webkit-scrollbar {


### PR DESCRIPTION
closes #302 

This PR addresses the issue where the text "No profile found" is not visible in light mode due to low contrast between the text color and the background color. Users with light mode enabled could not see the text, leading to a poor user experience.

![image](https://github.com/user-attachments/assets/2c50e718-5836-4597-be94-1fb7723f6682)
