### PR TITLE
Add .gitignore file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,20 @@
+# macOS
+.DS_Store
+
+# Windows
+Thumbs.db
+
+# Node.js 
+node_modules/
+npm-debug.log
+.env
+
+# Editor-specific configurations
+.vscode/
+.idea/
+
+# Log files
+*.log
+
+# Build output (for future use with static site generators)
+_site/


### PR DESCRIPTION
## Fixes #472 
### Add `.gitignore` File to Exclude `node_modules`

This PR introduces a `.gitignore` file to the repository, which now includes the `node_modules` directory. As a result, you can safely delete the `node_modules` folder from the repository, as it’s no longer necessary to track it in version control.

With this update:
- Future commits will no longer include the `node_modules` folder, reducing unnecessary clutter in the repository.
- Any dependencies can be reinstalled via `npm install`, as they are still managed by the `package.json` and `package-lock.json` files.

If you'd like, I can submit another pull request to remove the `node_modules` folder from the repository, or feel free to handle that separately.

Let me know how you'd like to proceed!