### PR TITLE
fixed subheading font color for light theme on gh-pages

### DIFF
--- a/pages/githubbadge.html
+++ b/pages/githubbadge.html
@@ -337,7 +337,7 @@
             </div>
         </div>
 
-        <h2>📃 Achievement List 📃</h2>
+        <h2 class="themed-text">📃 Achievement List 📃</h2>
 
         <table>
             <thead>
@@ -573,7 +573,7 @@
         </table>
 
 
-        <h2>👋 Achievement Skin Tone 👋</h2>
+        <h2 class="themed-text">👋 Achievement Skin Tone 👋</h2>
         <p>Some achievements' appearance depends on your Emoji Skin Tone Preference.</p>
         <p>You can change your preferred Skin Tone by going to <a
                 href="https://github.com/settings/appearance">appearance settings</a>.</p>
@@ -689,7 +689,7 @@
 
         </div>
 
-        <h2>✨ Highlights Badges ✨</h2>
+        <h2 class="themed-text">✨ Highlights Badges ✨</h2>
 
         <table>
             <thead>
@@ -758,7 +758,7 @@
                 </tr>
             </tbody>
         </table>
-        <h2>❌ Badges no longer earnable ❌ </h2>
+        <h2 class="themed-text">❌ Badges no longer earnable ❌ </h2>
         <table>
             <thead>
                 <tr>

--- a/styles/githubbadge.css
+++ b/styles/githubbadge.css
@@ -108,6 +108,16 @@ body.theme-dark .container{
 body.theme-dark .center {
   background-color: black !important;
 }
+body.dark-mode .themed-text {
+  color: white;
+}
+
+body:not(.dark-mode) .themed-text {
+  color: black;
+}
+body.dark-mode .themed-text {
+  color: white;
+}
 /* Light Mode Styles */
 .darkmodeimg {
   display: none;


### PR DESCRIPTION
This pull request addresses an issue with the font color of the subheading on the GitHub badge page, ensuring that it is suitable for the light theme. The previous font color was not legible, and this change improves readability and enhances the user experience for those using the light theme.