### PR TITLE
bugfix: add correct github url

### DIFF
--- a/index.html
+++ b/index.html
@@ -86,7 +86,7 @@
         </a>
       </div>
       <div class="icon-content">
-        <a href="https://github.com/recodehive" target="_blank" aria-label="GitHub" data-social="github">
+        <a href="https://github.com/recodehive/awesome-github-profiles" target="_blank" aria-label="GitHub" data-social="github">
           <i class="fab fa-github"></i>
           <div class="filled"></div>
         </a>


### PR DESCRIPTION
### **Fixes #609** 

Now when the github icon is clicked, user gets redirected to this repository
@dinxsh kindly add the labels [gssoc-ext](https://github.com/recodehive/awesome-github-profiles/labels/gssoc-ext) , [hacktoberfest-accepted](https://github.com/recodehive/awesome-github-profiles/labels/hacktoberfest-accepted) , [level1](https://github.com/recodehive/awesome-github-profiles/labels/level1) / [level2](https://github.com/recodehive/awesome-github-profiles/labels/level2) / [level3](https://github.com/recodehive/awesome-github-profiles/labels/level3)