### PR TITLE
Fixed naming inconsistency in repository references

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
-<h2 align="center">Awesome Github Profile</h2>
+<h2 align="center">awesome-github-profiles</h2>
 
 <div align="center">
   
 <!-- ALL-CONTRIBUTORS-BADGE:START - Do not remove or modify this section -->
 [![All Contributors](https://img.shields.io/badge/all_contributors-76-orange.svg?style=flat-square)](#contributors-)
 <!-- ALL-CONTRIBUTORS-BADGE:END -->
-🔍Welcome to the awesome github profiles repo project! 🌟.
+🔍Welcome to the awesome-github-profiles repo project! 🌟.
 
 <p>This README will guide you through the contribution process and provide essential information about the project.</p>
 </div>
@@ -161,7 +161,7 @@ Forking allows you to create a personal copy of the repository, where you can ex
 
 ### Navigate to the Repository:
 
-- Go to the Awesome GitHub Profiles repository.
+- Go to the awesome-gitHub-profiles repository.
 
 ### Click on Fork:
 
@@ -175,7 +175,7 @@ Forking allows you to create a personal copy of the repository, where you can ex
 
 - Use the command below to clone your fork to your local machine:
   ```bash
-  git clone https://github.com/YOUR_USERNAME/Awesome-Github-Profiles.git
+  git clone https://github.com/YOUR_USERNAME/awesome-github-profiles.git
   ```
 
 <h2 id="tutorials">Tutorials</h2>
@@ -223,7 +223,7 @@ To ensure a smooth collaboration process, Follow these steps:
 
    - Run the following command in your terminal:
      ```bash
-     git clone https://github.com/YOUR_USERNAME/Awesome-Github-Profiles.git
+     git clone https://github.com/YOUR_USERNAME/awesome-github-profiles.git
      ```
    - This command downloads your fork to your local machine.
 
@@ -231,7 +231,7 @@ To ensure a smooth collaboration process, Follow these steps:
 
    - Navigate into the cloned repository:
      ```bash
-     cd Awesome-Github-Profiles
+     cd awesome-github-profiles
      ```
    - Create a new branch for your feature or fix:
      ```bash


### PR DESCRIPTION
This pull request addresses the inconsistency in the naming of the repository throughout the project documentation. In some places, the repository was referred to as "Awesome GitHub Profiles" instead of  "Awesome-Github-Profiles" such as 
1.  
 
![image](https://github.com/user-attachments/assets/f760dc7d-8e20-441a-8ac3-6fbfc2d8858d)
2.
![image](https://github.com/user-attachments/assets/6136091b-1900-48cb-82b6-6e280c7c0191)
3.
![image](https://github.com/user-attachments/assets/7fafac11-2bc4-4f6e-94a9-a5f9a5c9aee8)


Changes Made:
Standardized all references to "Awesome-Github-Profiles" for consistency, particularly in the README.md file.

Please review and let me know if further adjustments are needed. Thanks!

Closes #604 