### PR TITLE
[fix] correct readme on main branch for easier instructions, create CONTRIBUTING.md file

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,82 @@
+# Contributing to Awesome GitHub Profiles
+
+Thank you for your interest in contributing to the **Awesome GitHub Profiles** project! We appreciate your time and effort. Follow the steps below to contribute successfully.
+
+## Getting Started
+
+### 1. Fork the Repository
+
+Click the **Fork** button at the top right of the repository page. This creates a copy of the repository under your GitHub account.
+
+### 2. Clone Your Fork
+
+After forking, clone your repository to your local machine:
+
+```bash
+git clone https://github.com/YOUR_USERNAME/awesome-github-profiles.git
+```
+
+Replace `YOUR_USERNAME` with your GitHub username.
+
+### 3. Switch to the `gh-pages` Branch
+
+Since the main code is in the `gh-pages` branch, navigate to that branch after cloning:
+
+```bash
+cd awesome-github-profiles
+git checkout gh-pages
+```
+
+### 4. Create a New Branch
+
+Create a new branch for your feature or bug fix:
+
+```bash
+git checkout -b your-feature-branch
+```
+
+Use a descriptive name for your branch (e.g., `add-new-profile`, `fix-readme-typo`).
+
+### 5. Make Your Changes
+
+Make the necessary changes in your local repository. Follow the project's coding style and guidelines to ensure consistency.
+
+### 6. Test Your Changes
+
+If applicable, test your changes locally to ensure nothing breaks. This can include:
+
+- Running the project to verify functionality.
+- Running tests if the project includes any testing tools.
+
+### 7. Stage and Commit Your Changes
+
+Once your changes are made, stage the files you want to commit:
+
+```bash
+git add .
+```
+
+Commit your changes with a clear message:
+
+```bash
+git commit -m "Add new profile"  # Be specific about what changes were made.
+```
+
+### 8. Push to Your Fork
+
+Push your new branch to your forked repository:
+
+```bash
+git push origin your-feature-branch
+```
+
+### 9. Submit a Pull Request (PR)
+
+Navigate to the original repository on GitHub, and you should see an option to create a Pull Request. Click that and fill in the necessary details:
+
+- Reference any issue your PR addresses (e.g., "Closes #123").
+- Explain clearly what your changes do.
+
+After submitting your PR, the maintainers will review it. You may receive feedback or requests for changes, so keep an eye on the comments.
+
+---

--- a/README.md
+++ b/README.md
@@ -274,6 +274,7 @@ To ensure a smooth collaboration process, Follow these steps:
 9. **Create a Pull Request:**
    - Navigate to the original repository where you want to propose your changes.
    - Click on "New Pull Request" and follow the instructions to submit your changes for review.
+For even more detailed instructions on how to contribute, you can always check out the [CONTRIBUTING.md](./CONTRIBUTING.md) file.
 
 <h2 id="special-thanks">Special Thanks 🙇</h2>
 

--- a/README.md
+++ b/README.md
@@ -229,9 +229,10 @@ To ensure a smooth collaboration process, Follow these steps:
 
 3. **Create a Branch:**
 
-   - Navigate into the cloned repository:
+   - Navigate into the cloned repository and switch to the `gh-pages` branch:
      ```bash
      cd awesome-github-profiles
+     git checkout gh-pages
      ```
    - Create a new branch for your feature or fix:
      ```bash


### PR DESCRIPTION
### Description

This PR corrects the readme on the `main` branch by making users switch to the working branch `gh-pages` branch before creating a new branch to add the feature, this is to ease the process of adding a new feature for beginners who don't understand the ins and outs of git on the CLI, addressing issue #683. Now I've created the CONTRIBUTING.md file to be put into the `main` branch as well as linked to it on the readme page using a hyperlink.