### PR TITLE
[fix] add CONTRIBUTING.md file to the gh-pages branch, correct invalid hyperlink

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,82 @@
+# Contributing to Awesome GitHub Profiles
+
+Thank you for your interest in contributing to the **Awesome GitHub Profiles** project! We appreciate your time and effort. Follow the steps below to contribute successfully.
+
+## Getting Started
+
+### 1. Fork the Repository
+
+Click the **Fork** button at the top right of the repository page. This creates a copy of the repository under your GitHub account.
+
+### 2. Clone Your Fork
+
+After forking, clone your repository to your local machine:
+
+```bash
+git clone https://github.com/YOUR_USERNAME/awesome-github-profiles.git
+```
+
+Replace `YOUR_USERNAME` with your GitHub username.
+
+### 3. Switch to the `gh-pages` Branch
+
+Since the main code is in the `gh-pages` branch, navigate to that branch after cloning:
+
+```bash
+cd awesome-github-profiles
+git checkout gh-pages
+```
+
+### 4. Create a New Branch
+
+Create a new branch for your feature or bug fix:
+
+```bash
+git checkout -b your-feature-branch
+```
+
+Use a descriptive name for your branch (e.g., `add-new-profile`, `fix-readme-typo`).
+
+### 5. Make Your Changes
+
+Make the necessary changes in your local repository. Follow the project's coding style and guidelines to ensure consistency.
+
+### 6. Test Your Changes
+
+If applicable, test your changes locally to ensure nothing breaks. This can include:
+
+- Running the project to verify functionality.
+- Running tests if the project includes any testing tools.
+
+### 7. Stage and Commit Your Changes
+
+Once your changes are made, stage the files you want to commit:
+
+```bash
+git add .
+```
+
+Commit your changes with a clear message:
+
+```bash
+git commit -m "Add new profile"  # Be specific about what changes were made.
+```
+
+### 8. Push to Your Fork
+
+Push your new branch to your forked repository:
+
+```bash
+git push origin your-feature-branch
+```
+
+### 9. Submit a Pull Request (PR)
+
+Navigate to the original repository on GitHub, and you should see an option to create a Pull Request. Click that and fill in the necessary details:
+
+- Reference any issue your PR addresses (e.g., "Closes #123").
+- Explain clearly what your changes do.
+
+After submitting your PR, the maintainers will review it. You may receive feedback or requests for changes, so keep an eye on the comments.
+
+---

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ This is the all in one place of awesome-github-profiles.
 ## Contribute
 
 Contributions are always welcome!
-Please read the [contribution guidelines](contributing.md) first.
+Please read the [Contribution Guidelines](./CONTRIBUTING.md) first.
 
 ## Special Thanks 🙇
 - [Dinesh Talwadker](https://github.com/dinxsh) [Hemant](https://github.com/dinxsh), [Nishant](https://github.com/dinxsh), [Ayushman](https://github.com/dinxsh)for being a core for this repo!


### PR DESCRIPTION
### Description

As previously mentioned in issue #705, the readme on the `gh-pages` branch links to an invalid link, since there is no CONTRIBUTING.md file, and even the link is not linking correctly to a file according to the Github syntax `./CONTRIBUTING.md`
The old text in the README.md

``` MD
Contributions are always welcome!
Please read the [contribution guidelines](contributing.md) first.
```
The solution: 
```MD
Contributions are always welcome!
Please read the [Contribution Guidelines](./CONTRIBUTING.md) first.
```