### PR TITLE
Fixes in Modal | Issue #775

### DIFF
--- a/styles/modal.css
+++ b/styles/modal.css
@@ -82,3 +82,18 @@
     margin-left: 10px;
   }
   
+body.dark-mode .modal-content p {
+  color: rgb(181, 181, 181);
+}
+
+body.dark-mode .modal-content h2 {
+  color: white;
+}
+
+body.dark-mode .add-profile-button:hover {
+  background-color: #5f5f5f;
+}
+
+body.dark-mode .close-button {
+  color: #ffffff;
+}

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -1393,18 +1393,17 @@ a {
 }
 
 #progressBarContainer {
-    position: fixed;
-    top: 0;
-    left: 0;
-    width: 100%;
-    height: 7px;
-    background-color: #333; 
-    z-index: 9999; 
-  }
-  
-  #progressBar {
-    height: 100%;
-    width: 0%; 
-    background: white;
-    transition: width 0.2s ease; 
-  }
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 7px;
+  background-color: #333; 
+  z-index: 9999; 
+}
+#progressBar {
+  height: 100%;
+  width: 0%; 
+  background: white;
+  transition: width 0.2s ease; 
+}


### PR DESCRIPTION
Error: Profile Addition PopUp Closing Icon Not Showing in Dark Mode
Fixes :

1. Closing icon is there but is not visible because of its color.
2. Also text is not showing.
3. Also modal is not closing
4. Button's color on hover also not matched (changed to same as modal color)


https://github.com/user-attachments/assets/7030af3c-7d75-4502-a2d0-2cc1702cb219

