### PR TITLE
Solved #825, changed youtube link to redirect users directly to recodehive's official youtube channel page.

### DIFF
--- a/index.html
+++ b/index.html
@@ -98,7 +98,7 @@
         </a>
       </div>
       <div class="icon-content">
-        <a href="https://stream.recodehive.com/github" target="_blank" aria-label="YouTube" data-social="youtube">
+        <a href="https://www.youtube.com/@RecodeHive" target="_blank" aria-label="YouTube" data-social="youtube">
           <i class="fab fa-youtube"></i>
           <div class="filled"></div>
         </a>


### PR DESCRIPTION
solved #825 (Suggestion: Change YouTube Link to Direct Users to Channel) 

previously : the youtube icon redirected users to a video from the channel (introduction to git)
now : the youtube icon redirect users to the channel's official youtube page. 

please add the hacktoberfest or hacktoberfest-accepted label , and gssoc-extd on the PR 
thankyou! 