### PR TITLE
Search bar fixed in max-width of 530px

### DIFF
--- a/styles/styles.css
+++ b/styles/styles.css
@@ -1319,7 +1319,8 @@ a {
     width: 55%;
   }
   .fa-search{
-    margin-left: 0.2rem;
+    margin-left: 0.3rem;
+    font-size: 0.9rem;
   }
 }
 

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -1313,7 +1313,15 @@ a {
   }
 }
 
-
+@media(max-width: 530px){
+  .search-input{
+    font-size: 12px;
+    width: 55%;
+  }
+  .fa-search{
+    margin-left: 0.2rem;
+  }
+}
 
 
 .line.show{


### PR DESCRIPTION
ISSUE #734 

Fixed the search bar issue. That overlap the search icon over the placeholder. As I mention on the ISSUE #734 

I fixed this.
Here is the demo -


https://github.com/user-attachments/assets/abd339f1-7067-4e09-9832-461124b1aba7


Please merge this sir @sanjay-kv 


`Please add all the necessary labels.`