### PR TITLE
Reduce number of visible profiles on the page

### DIFF
--- a/scripts/retriveprofile.js
+++ b/scripts/retriveprofile.js
@@ -15,7 +15,7 @@ var firebaseConfig = {
 firebase.initializeApp(firebaseConfig);
 
 let currentPage=1;
-const profilesPerPage = 20; // Number of profiles per page
+const profilesPerPage = 18; // Number of profiles per page
 
 document.addEventListener("DOMContentLoaded", function () {
   let contributors = [];


### PR DESCRIPTION
https://github.com/user-attachments/assets/41eb5722-2290-41b5-a0a3-268bdfe09925

### **Description:**

This pull request reduced the number of profiles displayed on a single page. Now, the profiles are limited to 18 per page, and users can navigate between pages using the provided "Previous" and "Next" buttons.

This pull request **closes issue #905**.

### **Labels:** as in the issue
- `hacktoberfest-accepted`
- `GSSOC-EXT`
- `level1`

