### PR TITLE
Fixed quickdraw section and added video tutorial link || ISSUE #912

### DIFF
--- a/pages/githubbadge.html
+++ b/pages/githubbadge.html
@@ -420,7 +420,9 @@
                     <td><img src="https://raw.githubusercontent.com/recodehive/awesome-github-profiles/main/assets/Badges/Quick-Draw/PNG/Skin-Tones/QuickDraw_SkinTone1.png"
                             width="60px" alt="Quickdraw"></td>
                     <td>Quickdraw</td>
-                    <td>Gitty up!<br>(closed an issue / pull request within 5 minutes of opening)</td>
+                    <td>Gitty up!<br>If you closed an issue / pull request within 5 minutes of opening you will unlock this badge<br>
+                    <a href="https://www.youtube.com/watch?v=BNKSlT8jLQ0">Watch the Video Tutorial</a>
+                    </td>
                     <td>
                         <table>
                             <thead>


### PR DESCRIPTION
I have added the video tutorial link in the quickdraw section and modified the statement about it.


https://github.com/user-attachments/assets/45a71495-b931-4e6e-a2e7-77d9bc7c076f

This PR closes ISSUE #912 
@sanjay-kv @HimangshuSharma01 