### PR TITLE
dark mode enhancement - placeholder text and footer

### DIFF
--- a/index.html
+++ b/index.html
@@ -314,7 +314,7 @@
       <div class="footer-bottom">
         <div class="footer-container">
           <p class="footer-copyright">
-            &copy;<a href = "https://stream.recodehive.com/github"><span id="dynamic-year"></span> Recode-Hive. Made with 🖤️ by the community. All rights reserved.</a> 
+            &copy;<a href = "https://stream.recodehive.com/github" class="footer-copy"><span id="dynamic-year"></span> Recode-Hive. Made with 🖤️ by the community. All rights reserved.</a> 
           </p>
         </div>
       </div>

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -624,7 +624,8 @@ body.dark-mode .navbar-link:hover {
   display: flex;
   flex-wrap: wrap;
   justify-content: space-between;
-  padding: 20px 0;
+  padding: 25px 10px;
+  padding-bottom: 70px;
 }
 
 .footer-info {
@@ -640,18 +641,19 @@ body.dark-mode .navbar-link:hover {
 }
 
 .footer-description {
+  margin-top: -2%;
   flex: 1 1 300px;
   max-width: 500px;
   margin-right: 30px;
 }
 
 .footer-logo {
-  width: 475px;
-  height: 200px;
+  width: 80%;
   cursor: pointer;
 }
 
 .footer-section {
+  margin-top: -8%;
   margin-right: 20px;
 }
 
@@ -718,6 +720,9 @@ body.dark-mode .navbar-link:hover {
 }
 
 /* Dark mode styles */
+.dark-mode .search-input::placeholder {
+  color: rgb(228, 228, 228); 
+}
 body.dark-mode .footer-2 {
   background: #333;
 }
@@ -731,7 +736,7 @@ body.dark-mode .footer-info img {
 }
 
 body.dark-mode .footer-heading {
-  color: #fff;
+  color: #d5d5d5;
 }
 
 body.dark-mode .footer-button {
@@ -741,6 +746,12 @@ body.dark-mode .footer-button {
 
 body.dark-mode .footer-button:hover {
   background-color: #e0e0e0;
+}
+.dark-mode .footer-copyright{
+  color:white;
+}
+.dark-mode .footer-copy{
+  color:rgb(236, 235, 235);
 }
 
 /* Responsive adjustments */


### PR DESCRIPTION
Fixes: #951 
- Changes made in dark mode 
1) placeholder text better visibility
- Footer changes
1) properly aligned content in footer of all pages
2) better visibility in dark mode

#### Before:
<img width="1440" alt="Screenshot 2024-10-22 at 3 50 59 PM" src="https://github.com/user-attachments/assets/cc1ebb47-2fbc-467b-af3c-29367b2194bb">
<img width="847" alt="Screenshot 2024-10-22 at 3 50 45 PM" src="https://github.com/user-attachments/assets/2f6a2c7a-b093-4b54-82fe-d5da125562cc">

#### After:
<img width="1440" alt="Screenshot 2024-10-22 at 3 51 05 PM" src="https://github.com/user-attachments/assets/3e115403-b3e7-44d8-bb92-8c13c3e4b47e">
<img width="870" alt="Screenshot 2024-10-22 at 3 50 39 PM" src="https://github.com/user-attachments/assets/20ca88f3-7a1c-4a17-97dc-fc1259203f44">
