### PR TITLE
[fix] remove redundant sections containing both `Learn` and `Blog` sections, and rename standalone `Learn` sections to `Blog` 

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,3 @@
 {
-    "liveServer.settings.port": 5501
+    "liveServer.settings.port": 5502
 }

--- a/index.html
+++ b/index.html
@@ -131,7 +131,7 @@
         class="navbar-link">Add Profile</a>
         <a href="#" class="navbar-link">Tools</a>
         <a href="./pages/events.html" class="navbar-link">Events</a>
-        <a href="./pages/blog.html" class="navbar-link">Learn</a>
+        <a href="./pages/blog.html" class="navbar-link">Blog</a>
         <a href="./pages/compare.html" class="navbar-link">Compare</a>
         <a href="login.html" class="navbar-link">Login</a>
 
@@ -159,7 +159,6 @@
       <a href="./pages/events.html" class="navbar-links">Events</a>
       <a href="pages/blog.html" class="navbar-links">Blog</a>
       <a href="https://github.com/recodehive/awesome-github-profiles/issues/new?assignees=&labels=%E2%9E%95+profile&projects=&template=add_profile.md&title=Add+Profile%3A+" class="navbar-links">Add Profile</a>
-      <a href="pages/blog.html" class="navbar-links">Learn</a>
       <a href="login.html">Login</a>
       
       <div class="toggle-switch">

--- a/pages/blog.html
+++ b/pages/blog.html
@@ -165,11 +165,12 @@
 		</div>
 	</nav>
 	<div class="mobile-menu" id="mobile-menu">
-		<a href="events.html" class="navbar-links">Events</a>
 		<a href="githubbadge.html" class="navbar-links">Github-Badge</a>
+		<a href="#" class="navbar-links">Tools</a>
+		<a href="events.html" class="navbar-links">Events</a>
 		<a href="blog.html" class="navbar-links">Blog</a>
 		<a href="#" class="navbar-links">Add Profile</a>
-		<a href="#" class="navbar-links">Tools</a>
+
 	</div>
 	<div id="toast-container"></div>
 

--- a/pages/blog.html
+++ b/pages/blog.html
@@ -144,7 +144,7 @@
 				class="navbar-link">Add Profile</a>
 			<a href="#" class="navbar-link">Tools</a>
 			<a href="events.html" class="navbar-link">Events</a>
-			<a href="blog.html" class="navbar-link">Learn</a>
+			<a href="blog.html" class="navbar-link">Blog</a>
 			<a href="compare.html" class="navbar-link">Compare</a>
 
 
@@ -169,7 +169,6 @@
 		<a href="githubbadge.html" class="navbar-links">Github-Badge</a>
 		<a href="blog.html" class="navbar-links">Blog</a>
 		<a href="#" class="navbar-links">Add Profile</a>
-		<a href="blog.html" class="navbar-links">Learn</a>
 		<a href="#" class="navbar-links">Tools</a>
 	</div>
 	<div id="toast-container"></div>

--- a/pages/compare.html
+++ b/pages/compare.html
@@ -129,7 +129,7 @@
         class="navbar-link">Add Profile</a>
         <a href="#" class="navbar-link">Tools</a>
         <a href="events.html" class="navbar-link">Events</a>
-        <a href="blog.html" class="navbar-link">Learn</a>
+        <a href="blog.html" class="navbar-link">Blog</a>
         <a href="compare.html" class="navbar-link">Compare</a>
 
        
@@ -154,7 +154,6 @@
         <a href="#" class="navbar-links">Tools</a>
         <a href="events.html" class="navbar-links">Events</a>
         <a href="githubbadge.html" class="navbar-links">Github-Badge</a>
-        <a href="blog.html" class="navbar-links">Learn</a>
         <a href="blog.html" class="navbar-links">Blog</a>
         <a href="#" class="navbar-links">Add Profile</a>
     </div>

--- a/pages/construction.html
+++ b/pages/construction.html
@@ -129,7 +129,7 @@
       class="navbar-link">Add Profile</a>
       <a href="#" class="navbar-link">Tools</a>
       <a href="events.html" class="navbar-link">Events</a>
-      <a href="blog.html" class="navbar-link">Learn</a>
+      <a href="blog.html" class="navbar-link">Blog</a>
       <a href="compare.html" class="navbar-link">Compare</a>
 
      

--- a/pages/events.html
+++ b/pages/events.html
@@ -129,7 +129,7 @@
         class="navbar-link">Add Profile</a>
       <a href="#" class="navbar-link">Tools</a>
       <a href="events.html" class="navbar-link">Events</a>
-      <a href="blog.html" class="navbar-link">Learn</a>
+      <a href="blog.html" class="navbar-link">Blog</a>
       <a href="compare.html" class="navbar-link">Compare</a>
 
       <div class="toggle-switch">
@@ -154,7 +154,6 @@
     <a href="" class="navbar-links">Events</a>
     <a href="blog.html" class="navbar-links">Blog</a>
     <a href="#" class="navbar-links">Add Profile</a>
-    <a href="blog.html" class="navbar-links">Learn</a>
   </div>
   <div class="container">
     <h1 class="main-heading">Events Timeline</h1>

--- a/pages/exploremore.html
+++ b/pages/exploremore.html
@@ -123,7 +123,7 @@
         class="navbar-link">Add Profile</a>
       <a href="#" class="navbar-link">Tools</a>
       <a href="events.html" class="navbar-link">Events</a>
-      <a href="blog.html" class="navbar-link">Learn</a>
+      <a href="blog.html" class="navbar-link">Blog</a>
       <a href="compare.html" class="navbar-link">Compare</a>
 
 
@@ -147,7 +147,6 @@
     <a href="githubbadge.html" class="navbar-links">Github-Badge</a>
     <a href="#" class="navbar-links">Tools</a>
     <a href="events.html" class="navbar-links">Events</a>
-    <a href="blog.html" class="navbar-links">Learn</a>
     <a href="blog.html" class="navbar-links">Blog</a>
     <a href="https://github.com/recodehive/awesome-github-profiles/issues/new?assignees=&labels=%E2%9E%95+profile&projects=&template=add_profile.md&title=Add+Profile%3A+"
       class="navbar-links">Add Profile</a>

--- a/pages/faq.html
+++ b/pages/faq.html
@@ -209,7 +209,7 @@
         class="navbar-link">Add Profile</a>
         <a href="#" class="navbar-link">Tools</a>
         <a href="events.html" class="navbar-link">Events</a>
-        <a href="blog.html" class="navbar-link">Learn</a>
+        <a href="blog.html" class="navbar-link">Blog</a>
         <a href="compare.html" class="navbar-link">Compare</a>
 
        
@@ -235,7 +235,6 @@
           <a href="events.html" class="navbar-links">Events</a>
           <a href="blog.html" class="navbar-links">Blog</a>
           <a href="https://github.com/recodehive/awesome-github-profiles/issues/new?assignees=&labels=%E2%9E%95+profile&projects=&template=add_profile.md&title=Add+Profile%3A+" class="navbar-links">Add Profile</a>
-          <a href="blog.html" class="navbar-links">Learn</a>
     </div>
     <section class="faq-section">
         <div class="faq-header">

--- a/pages/githubbadge.html
+++ b/pages/githubbadge.html
@@ -409,7 +409,7 @@
                 class="navbar-link">Add Profile</a>
             <a href="#" class="navbar-link">Tools</a>
             <a href="events.html" class="navbar-link">Events</a>
-            <a href="blog.html" class="navbar-link">Learn</a>
+            <a href="blog.html" class="navbar-link">Blog</a>
             <a href="compare.html" class="navbar-link">Compare</a>
 
 
@@ -436,7 +436,6 @@
         <a href="blog.html" class="navbar-links">Blog</a>
         <a href="https://github.com/recodehive/awesome-github-profiles/issues/new?assignees=&labels=%E2%9E%95+profile&projects=&template=add_profile.md&title=Add+Profile%3A+"
             class="navbar-links">Add Profile</a>
-        <a href="blog.html" class="navbar-links">Learn</a>
     </div>
 
     <div class="container">

--- a/pages/help.html
+++ b/pages/help.html
@@ -209,7 +209,7 @@
         class="navbar-link">Add Profile</a>
         <a href="#" class="navbar-link">Tools</a>
         <a href="events.html" class="navbar-link">Events</a>
-        <a href="blog.html" class="navbar-link">Learn</a>
+        <a href="blog.html" class="navbar-link">Blog</a>
         <a href="compare.html" class="navbar-link">Compare</a>
 
        
@@ -235,7 +235,6 @@
           <a href="events.html" class="navbar-links">Events</a>
           <a href="blog.html" class="navbar-links">Blog</a>
           <a href="https://github.com/recodehive/awesome-github-profiles/issues/new?assignees=&labels=%E2%9E%95+profile&projects=&template=add_profile.md&title=Add+Profile%3A+" class="navbar-links">Add Profile</a>
-          <a href="blog.html" class="navbar-links">Learn</a>
     </div>
 
    <div class="main-container">

--- a/pages/saved-blogs.html
+++ b/pages/saved-blogs.html
@@ -124,7 +124,7 @@
           class="navbar-link">Add Profile</a>
           <a href="#" class="navbar-link">Tools</a>
           <a href="events.html" class="navbar-link">Events</a>
-          <a href="blog.html" class="navbar-link">Learn</a>
+          <a href="blog.html" class="navbar-link">Blog</a>
           <a href="compare.html" class="navbar-link">Compare</a>
   
          
@@ -149,7 +149,6 @@
               <a href="githubbadge.html" class="navbar-links">Github-Badge</a>
               <a href="blog.html" class="navbar-links">Blog</a>
               <a href="#" class="navbar-links">Add Profile</a>
-              <a href="blog.html" class="navbar-links">Learn</a>
             <a href="#" class="navbar-links">Tools</a>
     </div>
     <h1 style="text-align: center;">Saved Blogs</h1>


### PR DESCRIPTION
### Description

This PR closes issue #757, the commits I've made remove the redundant parts in the Navigation Menu (both for PC and Mobile for responsiveness) where sections `Learn` and `Blog` Link to the **same** [blog.html](https://github.com/recodehive/awesome-github-profiles/blob/gh-pages/pages/blog.html) page at the **same time**, and in the cases where a page contains only one section Named `Learn` it is now renamed to `Blog` to maintain consistency across all webpages.

### Screenshots
![image](https://github.com/user-attachments/assets/62203db4-7378-4ff2-89a0-5644fdb76d70)
