### PR TITLE
[fix] add Login Section and Dark Mode Button on Events and Blogs Pages

### DIFF
--- a/pages/blog.html
+++ b/pages/blog.html
@@ -146,6 +146,7 @@
 			<a href="events.html" class="navbar-link">Events</a>
 			<a href="blog.html" class="navbar-link">Blog</a>
 			<a href="compare.html" class="navbar-link">Compare</a>
+			<a href="../login.html" class="navbar-link">Login</a>
 
 
 			<div class="toggle-switch">
@@ -170,7 +171,17 @@
 		<a href="events.html" class="navbar-links">Events</a>
 		<a href="blog.html" class="navbar-links">Blog</a>
 		<a href="#" class="navbar-links">Add Profile</a>
-
+		<a href="../login.html">Login</a>
+      
+    <div class="toggle-switch">
+      <input type="checkbox" id="theme-toggle-mobile">
+      <label for="theme-toggle-mobile">
+        <div class="switch-button">
+          <span class="material-icons sun-icon">wb_sunny</span>
+          <span class="material-icons moon-icon">brightness_2</span>
+        </div>
+      </label>
+    </div>
 	</div>
 	<div id="toast-container"></div>
 

--- a/pages/events.html
+++ b/pages/events.html
@@ -131,6 +131,7 @@
       <a href="events.html" class="navbar-link">Events</a>
       <a href="blog.html" class="navbar-link">Blog</a>
       <a href="compare.html" class="navbar-link">Compare</a>
+      <a href="../login.html" class="navbar-link">Login</a>
 
       <div class="toggle-switch">
         <input type="checkbox" id="theme-toggle">
@@ -154,6 +155,17 @@
     <a href="" class="navbar-links">Events</a>
     <a href="blog.html" class="navbar-links">Blog</a>
     <a href="#" class="navbar-links">Add Profile</a>
+    <a href="../login.html">Login</a>
+      
+    <div class="toggle-switch">
+      <input type="checkbox" id="theme-toggle-mobile">
+      <label for="theme-toggle-mobile">
+        <div class="switch-button">
+          <span class="material-icons sun-icon">wb_sunny</span>
+          <span class="material-icons moon-icon">brightness_2</span>
+        </div>
+      </label>
+    </div>
   </div>
   <div class="container">
     <h1 class="main-heading">Events Timeline</h1>


### PR DESCRIPTION
### Description

This PR closes issue #1069, adding the `Login` Section to the Navigation Menu both for PC and Mobile versions of the website on the `Events` and `Blogs` Pages of the website, this is to maintain consistency with the rest of the Pages on the website that all have these features.

### Screenshots
#### Events Page
![image](https://github.com/user-attachments/assets/05c55008-c440-47df-bba3-2bbdca98ff61)
#### Blogs Page
![image](https://github.com/user-attachments/assets/2777cab0-d0aa-4368-809e-0c1bd1f046a7)


