### PR TITLE
[fix] remove tools section from Nav Menu

### DIFF
--- a/index.html
+++ b/index.html
@@ -129,7 +129,6 @@
         <a href="pages/githubbadge.html" class="navbar-link">Github-Badge</a>
         <a href="https://github.com/recodehive/awesome-github-profiles/issues/new?assignees=&labels=%E2%9E%95+profile&projects=&template=add_profile.md&title=Add+Profile%3A+"
         class="navbar-link">Add Profile</a>
-        <a href="#" class="navbar-link">Tools</a>
         <a href="./pages/events.html" class="navbar-link">Events</a>
         <a href="./pages/blog.html" class="navbar-link">Blog</a>
         <a href="./pages/compare.html" class="navbar-link">Compare</a>
@@ -155,7 +154,6 @@
   
     <div class="mobile-menu" id="mobile-menu">
       <a href="pages/githubbadge.html" class="navbar-links">Github-Badge</a>
-      <a href="#" class="navbar-links">Tools</a>
       <a href="./pages/events.html" class="navbar-links">Events</a>
       <a href="pages/blog.html" class="navbar-links">Blog</a>
       <a href="https://github.com/recodehive/awesome-github-profiles/issues/new?assignees=&labels=%E2%9E%95+profile&projects=&template=add_profile.md&title=Add+Profile%3A+" class="navbar-links">Add Profile</a>

--- a/pages/blog.html
+++ b/pages/blog.html
@@ -142,7 +142,6 @@
 			<a href="githubbadge.html" class="navbar-link">Github-Badge</a>
 			<a href="https://github.com/recodehive/awesome-github-profiles/issues/new?assignees=&labels=%E2%9E%95+profile&projects=&template=add_profile.md&title=Add+Profile%3A+"
 				class="navbar-link">Add Profile</a>
-			<a href="#" class="navbar-link">Tools</a>
 			<a href="events.html" class="navbar-link">Events</a>
 			<a href="blog.html" class="navbar-link">Blog</a>
 			<a href="compare.html" class="navbar-link">Compare</a>
@@ -167,7 +166,6 @@
 	</nav>
 	<div class="mobile-menu" id="mobile-menu">
 		<a href="githubbadge.html" class="navbar-links">Github-Badge</a>
-		<a href="#" class="navbar-links">Tools</a>
 		<a href="events.html" class="navbar-links">Events</a>
 		<a href="blog.html" class="navbar-links">Blog</a>
 		<a href="#" class="navbar-links">Add Profile</a>

--- a/pages/compare.html
+++ b/pages/compare.html
@@ -127,7 +127,6 @@
         <a href="githubbadge.html" class="navbar-link">Github-Badge</a>
         <a href="https://github.com/recodehive/awesome-github-profiles/issues/new?assignees=&labels=%E2%9E%95+profile&projects=&template=add_profile.md&title=Add+Profile%3A+" 
         class="navbar-link">Add Profile</a>
-        <a href="#" class="navbar-link">Tools</a>
         <a href="events.html" class="navbar-link">Events</a>
         <a href="blog.html" class="navbar-link">Blog</a>
         <a href="compare.html" class="navbar-link">Compare</a>
@@ -151,7 +150,6 @@
     </nav> 
     <div class="mobile-menu" id="mobile-menu">
       <a href="githubbadge.html" class="navbar-links">Github-Badge</a>
-        <a href="#" class="navbar-links">Tools</a>
         <a href="events.html" class="navbar-links">Events</a>
         <a href="githubbadge.html" class="navbar-links">Github-Badge</a>
         <a href="blog.html" class="navbar-links">Blog</a>

--- a/pages/construction.html
+++ b/pages/construction.html
@@ -127,7 +127,6 @@
       <a href="githubbadge.html" class="navbar-link">Github-Badge</a>
       <a href="https://github.com/recodehive/awesome-github-profiles/issues/new?assignees=&labels=%E2%9E%95+profile&projects=&template=add_profile.md&title=Add+Profile%3A+" 
       class="navbar-link">Add Profile</a>
-      <a href="#" class="navbar-link">Tools</a>
       <a href="events.html" class="navbar-link">Events</a>
       <a href="blog.html" class="navbar-link">Blog</a>
       <a href="compare.html" class="navbar-link">Compare</a>

--- a/pages/events.html
+++ b/pages/events.html
@@ -127,7 +127,6 @@
       <a href="githubbadge.html" class="navbar-link">Github-Badge</a>
       <a href="https://github.com/recodehive/awesome-github-profiles/issues/new?assignees=&labels=%E2%9E%95+profile&projects=&template=add_profile.md&title=Add+Profile%3A+"
         class="navbar-link">Add Profile</a>
-      <a href="#" class="navbar-link">Tools</a>
       <a href="events.html" class="navbar-link">Events</a>
       <a href="blog.html" class="navbar-link">Blog</a>
       <a href="compare.html" class="navbar-link">Compare</a>
@@ -151,7 +150,6 @@
   </nav>
   <div class="mobile-menu" id="mobile-menu">
     <a href="githubbadge.html" class="navbar-links">Github-Badge</a>
-    <a href="#" class="navbar-links">Tools</a>
     <a href="" class="navbar-links">Events</a>
     <a href="blog.html" class="navbar-links">Blog</a>
     <a href="#" class="navbar-links">Add Profile</a>

--- a/pages/exploremore.html
+++ b/pages/exploremore.html
@@ -121,7 +121,6 @@
       <a href="githubbadge.html" class="navbar-link">Github-Badge</a>
       <a href="https://github.com/recodehive/awesome-github-profiles/issues/new?assignees=&labels=%E2%9E%95+profile&projects=&template=add_profile.md&title=Add+Profile%3A+"
         class="navbar-link">Add Profile</a>
-      <a href="#" class="navbar-link">Tools</a>
       <a href="events.html" class="navbar-link">Events</a>
       <a href="blog.html" class="navbar-link">Blog</a>
       <a href="compare.html" class="navbar-link">Compare</a>
@@ -145,7 +144,6 @@
   </nav>
   <div class="mobile-menu" id="mobile-menu">
     <a href="githubbadge.html" class="navbar-links">Github-Badge</a>
-    <a href="#" class="navbar-links">Tools</a>
     <a href="events.html" class="navbar-links">Events</a>
     <a href="blog.html" class="navbar-links">Blog</a>
     <a href="https://github.com/recodehive/awesome-github-profiles/issues/new?assignees=&labels=%E2%9E%95+profile&projects=&template=add_profile.md&title=Add+Profile%3A+"

--- a/pages/faq.html
+++ b/pages/faq.html
@@ -207,7 +207,6 @@
         <a href="githubbadge.html" class="navbar-link">Github-Badge</a>
         <a href="https://github.com/recodehive/awesome-github-profiles/issues/new?assignees=&labels=%E2%9E%95+profile&projects=&template=add_profile.md&title=Add+Profile%3A+" 
         class="navbar-link">Add Profile</a>
-        <a href="#" class="navbar-link">Tools</a>
         <a href="events.html" class="navbar-link">Events</a>
         <a href="blog.html" class="navbar-link">Blog</a>
         <a href="compare.html" class="navbar-link">Compare</a>
@@ -231,7 +230,6 @@
     </nav> 
     <div class="mobile-menu" id="mobile-menu">
       <a href="#" class="navbar-links">Github-Badge</a>
-            <a href="#" class="navbar-links">Tools</a>
           <a href="events.html" class="navbar-links">Events</a>
           <a href="blog.html" class="navbar-links">Blog</a>
           <a href="https://github.com/recodehive/awesome-github-profiles/issues/new?assignees=&labels=%E2%9E%95+profile&projects=&template=add_profile.md&title=Add+Profile%3A+" class="navbar-links">Add Profile</a>

--- a/pages/githubbadge.html
+++ b/pages/githubbadge.html
@@ -407,7 +407,6 @@
             <a href="githubbadge.html" class="navbar-link">Github-Badge</a>
             <a href="https://github.com/recodehive/awesome-github-profiles/issues/new?assignees=&labels=%E2%9E%95+profile&projects=&template=add_profile.md&title=Add+Profile%3A+"
                 class="navbar-link">Add Profile</a>
-            <a href="#" class="navbar-link">Tools</a>
             <a href="events.html" class="navbar-link">Events</a>
             <a href="blog.html" class="navbar-link">Blog</a>
             <a href="compare.html" class="navbar-link">Compare</a>
@@ -431,7 +430,6 @@
     </nav>
     <div class="mobile-menu" id="mobile-menu">
         <a href="#" class="navbar-links">Github-Badge</a>
-        <a href="#" class="navbar-links">Tools</a>
         <a href="events.html" class="navbar-links">Events</a>
         <a href="blog.html" class="navbar-links">Blog</a>
         <a href="https://github.com/recodehive/awesome-github-profiles/issues/new?assignees=&labels=%E2%9E%95+profile&projects=&template=add_profile.md&title=Add+Profile%3A+"

--- a/pages/help.html
+++ b/pages/help.html
@@ -207,7 +207,6 @@
         <a href="githubbadge.html" class="navbar-link">Github-Badge</a>
         <a href="https://github.com/recodehive/awesome-github-profiles/issues/new?assignees=&labels=%E2%9E%95+profile&projects=&template=add_profile.md&title=Add+Profile%3A+" 
         class="navbar-link">Add Profile</a>
-        <a href="#" class="navbar-link">Tools</a>
         <a href="events.html" class="navbar-link">Events</a>
         <a href="blog.html" class="navbar-link">Blog</a>
         <a href="compare.html" class="navbar-link">Compare</a>
@@ -231,7 +230,6 @@
     </nav> 
     <div class="mobile-menu" id="mobile-menu">
       <a href="#" class="navbar-links">Github-Badge</a>
-            <a href="#" class="navbar-links">Tools</a>
           <a href="events.html" class="navbar-links">Events</a>
           <a href="blog.html" class="navbar-links">Blog</a>
           <a href="https://github.com/recodehive/awesome-github-profiles/issues/new?assignees=&labels=%E2%9E%95+profile&projects=&template=add_profile.md&title=Add+Profile%3A+" class="navbar-links">Add Profile</a>

--- a/pages/saved-blogs.html
+++ b/pages/saved-blogs.html
@@ -122,7 +122,6 @@
           <a href="githubbadge.html" class="navbar-link">Github-Badge</a>
           <a href="https://github.com/recodehive/awesome-github-profiles/issues/new?assignees=&labels=%E2%9E%95+profile&projects=&template=add_profile.md&title=Add+Profile%3A+" 
           class="navbar-link">Add Profile</a>
-          <a href="#" class="navbar-link">Tools</a>
           <a href="events.html" class="navbar-link">Events</a>
           <a href="blog.html" class="navbar-link">Blog</a>
           <a href="compare.html" class="navbar-link">Compare</a>
@@ -149,7 +148,6 @@
               <a href="githubbadge.html" class="navbar-links">Github-Badge</a>
               <a href="blog.html" class="navbar-links">Blog</a>
               <a href="#" class="navbar-links">Add Profile</a>
-            <a href="#" class="navbar-links">Tools</a>
     </div>
     <h1 style="text-align: center;">Saved Blogs</h1>
     <div style="width: 100%; display: flex; justify-content: center; margin-bottom: 20px; margin-left: 20px;">


### PR DESCRIPTION
### Description

This PR closes issue #1074, removing the `Tools` Section from the Navigation Menu both on PC and Mobile since it is incorrectly linked and there is no corresponding webpage for it in the `pages` folder. Please fix the **mislabeling** issue on PR #1073 since the issue has a higher level than the PR. Thanks. @sanjay-kv 