### PR TITLE
Fixed UI For Dark-Mode : Closes #1154-->The Link "Prepare For the Github Foundation exam" gets disappeared when we switch to dark-mode

### DIFF
--- a/styles/styles.css
+++ b/styles/styles.css
@@ -1520,3 +1520,12 @@ a {
     backface-visibility: hidden;
     transition: opacity 0.2s ease;
   }
+
+  /* Dark mode link styling */
+body.dark-mode a {
+  color: #f0f0f0; /* Set to a light color for visibility */
+}
+
+body.dark-mode a:hover {
+  color: #ccc; /* Slightly lighter on hover */
+}


### PR DESCRIPTION
Fix #1154 

## Bug

The Link "Prepare For the Github Foundation exam" gets disappeared when we switch to dark-mode

### Image 1
![image](https://github.com/user-attachments/assets/571f20f5-a4dd-49c1-926f-b20c668e8a96)

### Image 2
![image](https://github.com/user-attachments/assets/ecc6378b-5805-44f1-a172-5494dcbad095)

## After Fix 

### Image 1
![image](https://github.com/user-attachments/assets/58312b09-dd09-4cde-a20f-1ad001b3ec82)

### Image 2
![image](https://github.com/user-attachments/assets/86cd9a1e-d32b-4e08-8eec-432daa888796)

