### PR TITLE
changed the footer of the events page

### DIFF
--- a/pages/events.html
+++ b/pages/events.html
@@ -133,41 +133,25 @@
     <div class="footer-container">
         <div class="footer-content">
             <div class="footer-info">
-                <a href="#"><img src="../assets/recode.png" alt="Recode-Hive logo" class="footer-logo"></a>
-                
-                <!-- Social Media Icons below the logo -->
-                <div class="social-media-icons">
-                    <a href="https://github.com/sanjay-kv" target="_blank" aria-label="GitHub" data-social="github">
-                        <i class="fab fa-github" aria-hidden="true"></i>
-                        <div class="filled"></div>
-                    </a>
-                    <a href="https://stream.recodehive.com/github" target="_blank" aria-label="YouTube" data-social="youtube">
-                        <i class="fab fa-youtube" aria-hidden="true"></i>
-                        <div class="filled"></div>
-                    </a>
-                    <a href="https://www.linkedin.com/in/sanjay-k-v/" target="_blank" aria-label="LinkedIn" data-social="linkedin">
-                        <i class="fab fa-linkedin-in" aria-hidden="true"></i>
-                        <div class="filled"></div>
-                    </a>
-                    <a href="https://twitter.com/sanjay_kv_" target="_blank" aria-label="Twitter" data-social="twitter">
-                        <i class="fab fa-twitter" aria-hidden="true"></i>
-                        <div class="filled"></div>
-                    </a>
-                    <a href="https://www.facebook.com/sanjay.k.viswanathan/" target="_blank" aria-label="Facebook" data-social="facebook">
-                        <i class="fab fa-facebook-f" aria-hidden="true"></i>
-                        <div class="filled"></div>
-                    </a>
+                <a href="../index.html" style="text-decoration: none; color: #333;">
+                    <img src="../assets/recode.png" alt="Recode-Hive logo" class="footer-logo">
+                </a>
+                <div class="social-media-links">
+                    <a href="https://facebook.com/recodehive" target="_blank" class="social-icon"><i class="fab fa-facebook-f"></i></a>
+                    <a href="https://twitter.com/recodehive" target="_blank" class="social-icon"><i class="fab fa-twitter"></i></a>
+                    <a href="https://instagram.com/recodehive" target="_blank" class="social-icon"><i class="fab fa-instagram"></i></a>
+                    <a href="https://linkedin.com/company/recodehive" target="_blank" class="social-icon"><i class="fab fa-linkedin-in"></i></a>
+                    <a href="https://github.com/recodehive" target="_blank" class="social-icon"><i class="fab fa-github"></i></a>
                 </div>
-                <!-- End of Social Media Icons -->
-
             </div>
-            <div class="footer-links" style="text-align: left;"> <!-- Align to the left -->
+
+            <div class="footer-links">
                 <div class="footer-section">
                     <h6 class="footer-heading">ABOUT RECODE-HIVE</h6>
                     <div>
-                        <a href="pages/help.html" class="footer-link">Contact Us</a>
+                        <a href="help.html" class="footer-link">Contact Us</a>
                         <a href="https://github.com/recodehive/awesome-github-profiles/blob/main/CODE_OF_CONDUCT.md" class="footer-link">Code of Conduct</a>
-                        <a href="pages/faq.html" class="footer-link">FAQ's</a>
+                        <a href="faq.html" class="footer-link">FAQ</a>
                     </div>
                 </div>
                 <div class="footer-section">
@@ -175,16 +159,16 @@
                     <div>
                         <a href="https://github.com/recodehive/awesome-github-profiles/issues/new?assignees=&amp;labels=%E2%9E%95+profile&amp;projects=&amp;template=add_profile.md&amp;title=Add+Profile%3A+" class="footer-link">Add Your Profile</a>
                         <a href="https://github.com/recodehive/Support/issues/new?assignees=&amp;labels=invite+me+to+the+community&amp;projects=&amp;template=invitation.yml&amp;title=Please+invite+me+to+the+Recode-Hive+GitHub+Community+Organization" class="footer-link">Join the Organization</a>
-                        <!-- New Events Link -->
-                        <a href="./pages/events.html" class="footer-link">Events</a>
+                        <a href="events.html" class="footer-link">Events</a>
                     </div>
                 </div>
             </div>
+
             <div class="footer-description">
-                <h5>We focus on quality content for the right people at the right time⏱. What we are trying to do is help you
-                    brand personal skills through GitHub readme.md, listing the best profiles, and giving you the opportunity to
-                    list your profile to the world 🌎.</h5>
-                <a href="https://stream.recodehive.com/github" class="footer-button">Explore</a>
+                <h5>
+                  We focus on quality content for the right people at the right time⏱. What we are trying to do is help you brand personal skills through GitHub readme.md, listing the best profiles, and giving you the opportunity to list your profile to the world 🌎.
+                </h5>
+                <a href="exploremore.html" class="footer-button">Explore</a>
             </div>
         </div>
     </div>
@@ -192,35 +176,38 @@
     <div class="footer-bottom">
         <div class="footer-container">
             <p class="footer-copyright">
-                © <span id="dynamic-year">2024</span> Recode-Hive. Made with 🖤 by the community. All rights reserved.
+                © <span id="dynamic-year">2024</span> Recode-Hive. Made with 🖤 by the community. All rights
+                reserved.
             </p>
-            <!-- Social Media Icons in the footer-bottom -->
-            <div class="social-media-icons">
-                <a href="https://github.com/sanjay-kv" target="_blank" aria-label="GitHub" data-social="github">
-                    <i class="fab fa-github" aria-hidden="true"></i>
-                    <div class="filled"></div>
-                </a>
-                <a href="https://stream.recodehive.com/github" target="_blank" aria-label="YouTube" data-social="youtube">
-                    <i class="fab fa-youtube" aria-hidden="true"></i>
-                    <div class="filled"></div>
-                </a>
-                <a href="https://www.linkedin.com/in/sanjay-k-v/" target="_blank" aria-label="LinkedIn" data-social="linkedin">
-                    <i class="fab fa-linkedin-in" aria-hidden="true"></i>
-                    <div class="filled"></div>
-                </a>
-                <a href="https://twitter.com/sanjay_kv_" target="_blank" aria-label="Twitter" data-social="twitter">
-                    <i class="fab fa-twitter" aria-hidden="true"></i>
-                    <div class="filled"></div>
-                </a>
-                <a href="https://www.facebook.com/sanjay.k.viswanathan/" target="_blank" aria-label="Facebook" data-social="facebook">
-                    <i class="fab fa-facebook-f" aria-hidden="true"></i>
-                    <div class="filled"></div>
-                </a>
-            </div>
-            <!-- End of Social Media Icons -->
         </div>
     </div>
+
+    <script>
+        document.getElementById("dynamic-year").textContent = new Date().getFullYear();
+    </script>
 </footer>
+
+<!-- Link to Font Awesome for icons -->
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.15.4/css/all.min.css">
+
+<!-- Custom CSS for social icons -->
+<style>
+    .social-media-links {
+        margin-top: 10px;
+        display: flex;
+        gap: 15px;
+    }
+
+    .social-icon {
+        font-size: 2rem; /* Increased icon size */
+        color: #333; /* Default color */
+        transition: transform 0.3s ease, color 0.3s ease; /* Smooth transition for transform and color */
+    }
+
+    .social-icon:hover {
+        color: #007bff; /* Change color on hover */
+        transform: rotate(20deg); /* Rotate 20 degrees on hover */}
+</style>
 
 <style>
     .footer-info {


### PR DESCRIPTION
Footer enhancement in the Learn page 
Issues: #1204
he footer components on the "Learn" page have a different design or structure compared to those on other pages like the GitHub Badge page and Event page. This inconsistency can create a disjointed user experience, leading to confusion and a less cohesive interface across the website.

Why It’s Important:
Having a consistent footer design across all pages ensures that users know where to find essential links or information without reorienting themselves on different pages.
A uniform look across all pages conveys attention to detail and quality, enhancing the overall perception of the site.

How the Feature Should Work:
The "Learn" page footer should be modified to match the design, layout, and functionality of the footers on other pages.
Here's the existing one:
![Screenshot 2024-11-03 153459](https://github.com/user-attachments/assets/f7a0c08c-9786-408b-8365-62f8b86e35fb)


This is the one I changed to:
![image](https://github.com/user-attachments/assets/b3e57bfe-cedf-4158-ae93-8f2e30c77a47)

