### PR TITLE
Fix Google Chrome alert

### DIFF
--- a/server.js
+++ b/server.js
@@ -8,6 +8,12 @@ const cors =require("cors");
 const app = express();
 const port = process.env.PORT || 3000;
 
+// Middleware to remove Google Chrome alert
+app.use((req, res, next) => {
+  res.setHeader('Content-Security-Policy', "script-src 'self'");
+  next();
+});
+
 // Middleware
 const allowedOrigins = [
   "https://recodehive.github.io/awesome-github-profiles",


### PR DESCRIPTION
Add middleware to remove Google Chrome alert.

* Add middleware to set Content-Security-Policy header to allow only self-hosted scripts
* Ensure the middleware is added before other routes

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/recodehive/awesome-github-profiles/pull/1243?shareId=010a24c2-71f8-47dc-92a6-254a43ef2857).