### PR TITLE
Remove Google Safe Browsing warning

### DIFF
--- a/index.html
+++ b/index.html
@@ -351,10 +351,6 @@
   <script src="scripts/speechRecognition.js"></script>
   <!-- Added script for new Twitter logo -->
   <script src="https://kit.fontawesome.com/856f4a44d7.js" crossorigin="anonymous"></script>
-  <div class="gtranslate_wrapper"></div>
-  <script>window.gtranslateSettings = { "default_language": "en", "detect_browser_language": true, "wrapper_selector": ".gtranslate_wrapper" }</script>
-  <script src="https://cdn.gtranslate.net/widgets/latest/float.js" defer></script>
-
 </body>
 
 </html>

--- a/login.html
+++ b/login.html
@@ -184,9 +184,6 @@
 
   </div>
   <script src="login.js"></script>
-  <div class="gtranslate_wrapper"></div>
-  <script>window.gtranslateSettings = { "default_language": "en", "detect_browser_language": true, "wrapper_selector": ".gtranslate_wrapper" }</script>
-  <script src="https://cdn.gtranslate.net/widgets/latest/float.js" defer></script>
 </body>
 
 </html>


### PR DESCRIPTION
Remove Google Translate script and wrapper to eliminate Google Safe Browsing warning.

* **index.html**
  - Remove `gtranslate_wrapper` div
  - Remove `gtranslateSettings` script tag
  - Remove `gtranslate` script tag

* **login.html**
  - Remove `gtranslate_wrapper` div
  - Remove `gtranslateSettings` script tag
  - Remove `gtranslate` script tag

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/recodehive/awesome-github-profiles/pull/1244?shareId=cf7a371a-c595-465b-ae80-cafd5cf6a867).