### PR TITLE
Fix dangerous site warning

### DIFF
--- a/server.js
+++ b/server.js
@@ -18,6 +18,8 @@ app.use((req, res, next) => {
 const allowedOrigins = [
   "https://recodehive.github.io/awesome-github-profiles",
   "http://127.0.0.1:5502",
+  "http://localhost:3000",
+  "https://example.com"
 ];
 
 app.use(


### PR DESCRIPTION
Add allowed origins to CORS middleware in `server.js`.

* Add "http://localhost:3000" and "https://example.com" to the allowed origins array in the CORS middleware configuration.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/recodehive/awesome-github-profiles/pull/1247?shareId=b0fd6915-60ad-4555-b7ca-f12098fb034e).