### PR TITLE
Fixed the footer logo for both compare.html and githubbadges.html

### DIFF
--- a/pages/blog.html
+++ b/pages/blog.html
@@ -16,13 +16,14 @@
 </head>
 
 <body>
+	<!--
 	<div id="preloader">
 		<div class="loader-wrapper">
 			<img src="recode-hive.png" alt="Logo" class="logo">
 			<div class="loader"></div>
 		</div>
 	</div>
-	
+	-->
 	<style>
 		#preloader {
 			position: fixed;

--- a/pages/blog.html
+++ b/pages/blog.html
@@ -16,14 +16,14 @@
 </head>
 
 <body>
-	<!--
+
 	<div id="preloader">
 		<div class="loader-wrapper">
 			<img src="recode-hive.png" alt="Logo" class="logo">
 			<div class="loader"></div>
 		</div>
 	</div>
-	-->
+	
 	<style>
 		#preloader {
 			position: fixed;

--- a/pages/compare.html
+++ b/pages/compare.html
@@ -285,9 +285,11 @@ body, html {
 }
 
 .footer-logo {
-  width: 500px;
-  height: 100px;
-  cursor: pointer;
+    width: auto;
+    height: 73px;
+    cursor: pointer;
+    padding-left: 20px;
+    padding-top: 40px;
 }
 
 .footer-section {

--- a/pages/githubbadge.html
+++ b/pages/githubbadge.html
@@ -251,6 +251,12 @@
             background: white;
             transition: width 0.2s ease; 
         }
+        .footer-logo {
+        width: auto;
+        height: auto;
+        max-width: 100%;
+        max-height: 100px; /* Adjust this value as needed */
+        }
     </style>
     <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
     <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;500&display=swap" rel="stylesheet" />

--- a/pages/githubbadge.html
+++ b/pages/githubbadge.html
@@ -253,10 +253,11 @@
         }
         .footer-logo {
         width: auto;
-        height: auto;
-        max-width: 100%;
-        max-height: 100px; /* Adjust this value as needed */
-        }
+        height: 73px;
+        cursor: pointer;
+        padding-left: 20px;
+        padding-top: 40px;
+}
     </style>
     <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
     <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;500&display=swap" rel="stylesheet" />

--- a/pages/githubbadge.html
+++ b/pages/githubbadge.html
@@ -18,15 +18,15 @@
         }
 
         .container {
-    max-width: 1200px;
-    margin: auto;
-    padding: 20px;
+        max-width: 1200px;
+        margin: auto;
+        padding: 20px;
     /* background: #fff; */
-    border-radius: 8px;
-    box-shadow: 0 0 10px rgba(0, 0, 0, 0.1);
-    overflow-x: auto; /* Enable horizontal scrolling */
-    -webkit-overflow-scrolling: touch; /* Smooth scrolling for iOS */
-}
+        border-radius: 8px;
+        box-shadow: 0 0 10px rgba(0, 0, 0, 0.1);
+        overflow-x: auto; /* Enable horizontal scrolling */
+        -webkit-overflow-scrolling: touch; /* Smooth scrolling for iOS */
+        }
 
         h1,
         h2 {
@@ -257,7 +257,8 @@
         cursor: pointer;
         padding-left: 20px;
         padding-top: 40px;
-}
+        object-fit: scale-down; /* Ensure the aspect ratio is maintained */
+        }
     </style>
     <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
     <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;500&display=swap" rel="stylesheet" />


### PR DESCRIPTION
Closes #1302 
Previously the footer logo were stretched or compressed. So brought the logo to a normal size.

![image](https://github.com/user-attachments/assets/3c642abb-3803-4922-954b-4188257ef857)
![image](https://github.com/user-attachments/assets/256a337a-2c12-4f08-adb4-e3087dcb5310)
