### PR TITLE
feat: Add issue and PR templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -1,0 +1,52 @@
+name: Bug report 🐞
+description: File a bug report
+title: "🐞[Bug]: "
+labels: 'bug'
+body:
+  - type: checkboxes
+    id: existing-issue
+    attributes:
+      label: Is there an existing issue for this?
+      description: Please search to see if an issue already exists for the bug you encountered.
+      options:
+        - label: I have searched the existing issues
+          required: true
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: Describe the bug
+      description: A concise description of what you are experiencing.
+      placeholder: Tell us what you see!
+    validations:
+      required: true
+  - type: textarea
+    id: expected-behaviour
+    attributes:
+      label: Expected behavior
+      description: A clear and concise description of what you expected to happen.
+    validations:
+      required: true
+  - type: textarea
+    id: screenshots
+    attributes:
+      label: Add ScreenShots
+      description: Add sufficient ScreenShots to explain your issue.
+  - type: dropdown
+    id: browsers
+    attributes:
+      label: What browsers are you seeing the problem on?
+      multiple: true
+      options:
+        - Firefox
+        - Chrome
+        - Safari
+        - Microsoft Edge
+  - type: checkboxes
+    id: terms
+    attributes:
+      label: Record
+      options:
+        - label: "I have read the Contributing Guidelines"
+          required: true
+        - label: "I want to work on this issue"
+          required: false

--- a/.github/ISSUE_TEMPLATE/documentation.yml
+++ b/.github/ISSUE_TEMPLATE/documentation.yml
@@ -1,0 +1,44 @@
+name: 📝 Documentation Update
+description: Improve Documentation
+title: "📝[Docs]: "
+labels: 'enhancement'
+body:
+  - type: checkboxes
+    id: existing-issue
+    attributes:
+      label: Is there an existing issue for this?
+      description: Please search to see if an issue already exists for the updates you want to make.
+      options:
+        - label: I have searched the existing issues
+          required: true
+  - type: textarea
+    id: issue-description
+    attributes:
+      label: Issue Description
+      description: Please provide a clear description of the documentation update you are suggesting.
+      placeholder: Describe the improvement or correction you'd like to see in the documentation.
+    validations:
+      required: true
+  - type: textarea
+    id: suggested-change
+    attributes:
+      label: Suggested Change
+      description: Provide details of the proposed change to the documentation.
+      placeholder: Explain how the documentation should be updated or corrected.
+    validations:
+      required: true
+  - type: textarea
+    id: rationale
+    attributes:
+      label: Rationale
+      description: Why is this documentation update necessary or beneficial?
+      placeholder: Explain the importance or reasoning behind the suggested change.
+  - type: checkboxes
+    id: terms
+    attributes:
+      label: Record
+      options:
+        - label: "I have read the Contributing Guidelines"
+          required: true
+        - label: "I want to work on this issue"
+          required: false

--- a/.github/ISSUE_TEMPLATE/feature.yml
+++ b/.github/ISSUE_TEMPLATE/feature.yml
@@ -1,0 +1,49 @@
+name: 💡Feature Request
+description: Suggest a feature
+title: "💡[Feature]: "
+labels: "enhancement"
+body:
+  - type: checkboxes
+    id: existing-issue
+    attributes:
+      label: Is there an existing issue for this?
+      description: Please search to see if an issue already exists for this feature.
+      options:
+        - label: I have searched the existing issues
+          required: true
+  - type: textarea
+    id: feature-description
+    attributes:
+      label: Feature Description
+      description: Please provide a detailed description of the feature you are requesting.
+      placeholder: Describe the new feature or enhancement you'd like to see.
+    validations:
+      required: true
+  - type: textarea
+    id: use-case
+    attributes:
+      label: Use Case
+      description: How would this feature enhance your use of the project?
+      placeholder: Describe a specific use case or scenario where this feature would be beneficial.
+    validations:
+      required: true
+  - type: textarea
+    id: benefits
+    attributes:
+      label: Benefits
+      description: What benefits would this feature bring to the project or community?
+      placeholder: Explain the advantages of implementing this feature.
+  - type: textarea
+    id: screenShots
+    attributes:
+      label: Add ScreenShots
+      description: If any...
+  - type: checkboxes
+    id: terms
+    attributes:
+      label: Record
+      options:
+        - label: "I have read the Contributing Guidelines"
+          required: true
+        - label: "I want to work on this issue"
+          required: false

--- a/.github/pull_request.md
+++ b/.github/pull_request.md
@@ -1,0 +1,34 @@
+## Description
+
+<!-- 
+Provide a brief summary of the changes made to the website and the motivation behind them. Include any relevant issues or tickets.
+This helps fast tracking your PR and merge it, Check the respective box below.
+-->
+Fixes # (issue)
+
+## Type of Change
+
+- [ ] New feature (e.g., new page, component, or functionality)
+- [ ] Bug fix (non-breaking change that fixes an issue)
+- [ ] UI/UX improvement (design, layout, or styling updates)
+- [ ] Performance optimization (e.g., code splitting, caching)
+- [ ] Documentation update (README, contribution guidelines, etc.)
+- [ ] Other (please specify):
+
+## Changes Made
+
+<!--
+Describe the key changes (e.g., new sections, updated components, responsive fixes).
+-->
+
+## Dependencies
+
+- List any new dependencies or tools required for this change.
+- Mention any version updates or configurations that need to be considered.
+
+## Checklist
+
+- [ ] My code follows the style guidelines of this project.
+- [ ] I have tested my changes across major browsers and devices
+- [ ] My changes do not generate new console warnings or errors .
+- [ ] This is already assigned Issue to me, not an unassigned issue.


### PR DESCRIPTION
This PR introduces issue and pull request templates.

Templates added:
- ``bug.yml
- `feature.yml`
- `documentation.yml`
- `pull_request.md`

Files are placed in the `.github/ `directories.

Resolves #1451 