### PR TITLE
fix: correct YouTube link for Pair Extraordinaire badge tutorial

### DIFF
--- a/pages/githubbadge.html
+++ b/pages/githubbadge.html
@@ -167,7 +167,7 @@
                         Requirement: VSCode IDE (bit difficult to get)<br>
                         You can raise a sample PR <a href="https://github.com/recodehive/Opensource-practice">here</a> by
                         adding to the existing readme file and tag me @sanjay-kv<br>
-                        <a href="https://youtu.be/BNKSlT8jLQ0">Watch the Video Tutorial</a>
+                        <a href="https://www.youtube.com/watch?v=ZoNO_e8PjiM">Watch the Video Tutorial</a>
                     </td>
                     </td>
                     <td>


### PR DESCRIPTION
Updated the incorrect YouTube URL for the Pair Extraordinaire badge video tutorial in githubbadge.html.

@sanjay-kv requesting a check :)

Old URL: https://youtu.be/BNKSlT8jLQ0
New URL: https://www.youtube.com/watch?v=ZoNO_e8PjiM