### PR TITLE
Fix badge table layout overflow on mobile (#1364)

### DIFF
--- a/styles/githubbadge.css
+++ b/styles/githubbadge.css
@@ -552,3 +552,85 @@ body.dark-mode .themed-text {
         padding-top: 40px;
         object-fit: scale-down; /* Ensure the aspect ratio is maintained */
         }
+
+/* Issue #1364: on mobile the badge tables overflow horizontally. The last
+   column holds a nested DEFAULT/BRONZE/SILVER/GOLD tier table, and crammed
+   into a narrow column on a phone it pushes the row off-screen. Below 768px
+   each badge row becomes a stacked card, so every cell (including the nested
+   tier table) gets the full viewport width instead of overflowing. The three
+   primary tables are direct children of .container; the tier tables live
+   inside a <td>, so the child combinator leaves them untouched. Desktop is
+   unchanged. */
+@media screen and (max-width: 768px) {
+    .container > table,
+    .container > table > tbody,
+    .container > table > tbody > tr,
+    .container > table > tbody > tr > td {
+        display: block;
+        width: 100%;
+        box-sizing: border-box;
+    }
+
+    .container > table > thead {
+        display: none;
+    }
+
+    .container > table > tbody > tr {
+        margin: 0 0 16px;
+        border: 1px solid #ddd;
+        border-radius: 8px;
+        padding: 12px;
+        overflow-x: auto; /* a very wide tier table scrolls inside its own card */
+    }
+
+    .container > table > tbody > tr > td {
+        border: none;
+        text-align: center;
+        padding: 6px 4px;
+    }
+
+    /* All three primary tables share Badge / Name / How to get as columns 1-3,
+       so labelling by position is safe. The 4th column exists only on the
+       achievement tables. */
+    .container > table > tbody > tr > td:nth-child(2)::before {
+        content: "Name: ";
+        font-weight: 700;
+    }
+
+    .container > table > tbody > tr > td:nth-child(3)::before {
+        content: "How to get: ";
+        font-weight: 700;
+    }
+
+    .container > table > tbody > tr > td:nth-child(4)::before {
+        content: "Needed amount";
+        font-weight: 700;
+        display: block;
+        margin-bottom: 6px;
+    }
+
+    .container > table > tbody > tr > td:first-child img {
+        max-width: 96px;
+        height: auto;
+    }
+
+    /* The nested tier table now sits in a full-width cell, so center it and
+       let it size to its content rather than stretching the card. */
+    .container > table td table {
+        width: auto;
+        margin: 8px auto 0;
+    }
+
+    /* Shrink the tier cells so all four columns (DEFAULT/BRONZE/SILVER/GOLD)
+       fit within the card instead of clipping GOLD off the right edge. */
+    .container > table td table th,
+    .container > table td table td {
+        padding: 3px 4px;
+        font-size: 11px;
+    }
+
+    .container > table td table img {
+        max-width: 44px;
+        height: auto;
+    }
+}


### PR DESCRIPTION
## What this fixes

On mobile the achievement tables overflowed sideways. The last column holds a nested DEFAULT/BRONZE/SILVER/GOLD tier table, and squeezed into a narrow column on a phone it pushed the row off-screen, so SILVER and GOLD were out of view.

## How

Below 768px each badge row stacks into a card, so every cell including the tier table gets the full width. Tier cells are shrunk so all four columns fit. Desktop is untouched: the rules live inside a `max-width: 768px` media query, and the desktop render is identical before and after.

CSS only, one file: `styles/githubbadge.css`.

## Proof

Before (SILVER and GOLD pushed off-screen):


<img width="500" height="2400" alt="01-before-mobile" src="https://github.com/user-attachments/assets/3373e024-d452-4c97-9db4-30208398de35" />


After (stacked cards, all four tiers visible):

<img width="500" height="2400" alt="02-after-mobile" src="https://github.com/user-attachments/assets/585abb37-f800-40c8-997c-83d941d87537" />


Desktop unchanged:

<img width="1200" height="1400" alt="03-desktop-unchanged" src="https://github.com/user-attachments/assets/6b31008b-3d10-4b0e-b0b7-b0c61f8a0cfe" />

Closes #1364
