### PR TITLE
Fix broken links on the GitHub badge page (#1363)

### DIFF
--- a/pages/githubbadge.html
+++ b/pages/githubbadge.html
@@ -502,7 +502,7 @@
                     </td>
                     <td>Developer Program Member</td>
                     <td>Be a registered member of the <a
-                            href="https://docs.github.com/en/developers/overview/github-developer-program">GitHub
+                            href="https://docs.github.com/en/integrations/concepts/github-developer-program">GitHub
                             Developer Program</a></td>
                 </tr>
                 <tr>
@@ -740,7 +740,7 @@
                     </a>
                     <div class="social-media-links">
                         <a href="https://facebook.com/recodehive" target="_blank" class="social-icon1"><i class="fab fa-facebook-f"></i></a>
-                        <a href="https://twitter.com/recodehive" target="_blank" class="social-icon2"><i class="fab fa-twitter"></i></a>
+                        <a href="https://x.com/sanjay_kv_" target="_blank" class="social-icon2"><i class="fab fa-twitter"></i></a>
                         <a href="https://instagram.com/recodehive" target="_blank" class="social-icon3"><i class="fab fa-instagram"></i></a>
                         <a href="https://linkedin.com/company/recodehive" target="_blank" class="social-icon4"><i class="fab fa-linkedin-in"></i></a>
                         <a href="https://github.com/recodehive" target="_blank" class="social-icon5"><i class="fab fa-github"></i></a>


### PR DESCRIPTION
## What this fixes

Broken and outdated links on the GitHub badge page.

- The social row linked `twitter.com/recodehive`, which returns 404. Changed it to `https://x.com/sanjay_kv_`, the handle used in the recodehive `.github` profile.
- The "GitHub Developer Program" link in the Developer Program badge row used the old `developers/overview/...` docs path that now redirects. Updated it to the current `integrations/concepts/github-developer-program` page.

## What I checked

I audited every image and link on the page before making changes:

- All 50 images return 200. No broken images.
- `twitter.com/recodehive` was the only link returning a hard 404.
- The other redirects are healthy and left alone: `facebook`/`instagram`/`youtu.be` are just www/canonical redirects, and the `github.com/settings` and `issues/new` links redirect to a login wall (they work when signed in), so none of those are actually broken.

Closes #1363
