### PR TITLE
fix: restore missing navbar links across all inner pages

### DIFF
--- a/pages/blog.html
+++ b/pages/blog.html
@@ -46,7 +46,10 @@
 			<span class="navbar-text">Recode Hive</span>
 		</a>
 		<div class="navbar-right">
-			<a href="githubbadge.html" class="navbar-link">Github-Badge</a>
+			<a href="githubbadge.html" class="navbar-link">Github-Badges</a>
+			<a href="devtools.html" class="navbar-link">Useful Devtools</a>
+			<a href="#" class="navbar-link">Tools</a>
+
 			<a href="https://github.com/recodehive/awesome-github-profiles/issues/new?assignees=&labels=%E2%9E%95+profile&projects=&template=add_profile.md&title=Add+Profile%3A+"
 				class="navbar-link">Add Profile</a>
 			<a href="events.html" class="navbar-link">Events</a>
@@ -72,7 +75,7 @@
 		</div>
 	</nav>
 	<div class="mobile-menu" id="mobile-menu">
-		<a href="githubbadge.html" class="navbar-links">Github-Badge</a>
+		<a href="githubbadge.html" class="navbar-links">Github-Badges</a>
 		<a href="events.html" class="navbar-links">Events</a>
 		<a href="blog.html" class="navbar-links">Blog</a>
 		<a href="https://github.com/recodehive/awesome-github-profiles/issues/new?assignees=&labels=%E2%9E%95+profile&projects=&template=add_profile.md&title=Add+Profile%3A+" class="navbar-links">Add Profile</a>

--- a/pages/compare.html
+++ b/pages/compare.html
@@ -27,13 +27,16 @@
         <span class="navbar-text">Recode Hive</span>
       </a>
       <div class="navbar-right">
-        <a href="githubbadge.html" class="navbar-link">Github-Badge</a>
+        <a href="githubbadge.html" class="navbar-link">Github-Badges</a>
+        <a href="devtools.html" class="navbar-link">Useful Devtools</a>
+        <a href="#" class="navbar-link">Tools</a>
+
         <a href="https://github.com/recodehive/awesome-github-profiles/issues/new?assignees=&labels=%E2%9E%95+profile&projects=&template=add_profile.md&title=Add+Profile%3A+" 
         class="navbar-link">Add Profile</a>
         <a href="events.html" class="navbar-link">Events</a>
         <a href="blog.html" class="navbar-link">Blog</a>
         <a href="compare.html" class="navbar-link">Compare</a>
-
+        <a href="../login.html" class="navbar-link">Login</a>
        
         <div class="toggle-switch">
           <input type="checkbox" id="theme-toggle">
@@ -52,9 +55,8 @@
       </div>
     </nav> 
     <div class="mobile-menu" id="mobile-menu">
-      <a href="githubbadge.html" class="navbar-links">Github-Badge</a>
+      <a href="githubbadge.html" class="navbar-links">Github-Badges</a>
       <a href="events.html" class="navbar-links">Events</a>
-      <a href="githubbadge.html" class="navbar-links">Github-Badge</a>
       <a href="blog.html" class="navbar-links">Blog</a>
       <a href="https://github.com/recodehive/awesome-github-profiles/issues/new?assignees=&labels=%E2%9E%95+profile&projects=&template=add_profile.md&title=Add+Profile%3A+" class="navbar-links">Add Profile</a>
       <div class="toggle-switch">

--- a/pages/construction.html
+++ b/pages/construction.html
@@ -28,12 +28,17 @@
       <span class="navbar-text">Recode Hive</span>
     </a>
     <div class="navbar-right">
-      <a href="githubbadge.html" class="navbar-link">Github-Badge</a>
+      <a href="githubbadge.html" class="navbar-link">Github-Badges</a>
+      <a href="devtools.html" class="navbar-link">Useful Devtools</a>
+      <a href="#" class="navbar-link">Tools</a>
+
       <a href="https://github.com/recodehive/awesome-github-profiles/issues/new?assignees=&labels=%E2%9E%95+profile&projects=&template=add_profile.md&title=Add+Profile%3A+" 
       class="navbar-link">Add Profile</a>
       <a href="events.html" class="navbar-link">Events</a>
       <a href="blog.html" class="navbar-link">Blog</a>
       <a href="compare.html" class="navbar-link">Compare</a>
+      <a href="../login.html" class="navbar-link">Login</a>
+
 
      
       <div class="toggle-switch">

--- a/pages/events.html
+++ b/pages/events.html
@@ -25,7 +25,10 @@
       <span class="navbar-text">Recode Hive</span>
     </a>
     <div class="navbar-right">
-      <a href="githubbadge.html" class="navbar-link">Github-Badge</a>
+      <a href="githubbadge.html" class="navbar-link">Github-Badges</a>
+      <a href="devtools.html" class="navbar-link">Useful Devtools</a>
+      <a href="#" class="navbar-link">Tools</a>
+
       <a href="https://github.com/recodehive/awesome-github-profiles/issues/new?assignees=&labels=%E2%9E%95+profile&projects=&template=add_profile.md&title=Add+Profile%3A+"
         class="navbar-link">Add Profile</a>
       <a href="events.html" class="navbar-link">Events</a>
@@ -50,7 +53,7 @@
     </div>
   </nav>
   <div class="mobile-menu" id="mobile-menu">
-    <a href="githubbadge.html" class="navbar-links">Github-Badge</a>
+    <a href="githubbadge.html" class="navbar-links">Github-Badges</a>
     <a href="" class="navbar-links">Events</a>
     <a href="blog.html" class="navbar-links">Blog</a>
     <a href="https://github.com/recodehive/awesome-github-profiles/issues/new?assignees=&labels=%E2%9E%95+profile&projects=&template=add_profile.md&title=Add+Profile%3A+" class="navbar-links">Add Profile</a>

--- a/pages/exploremore.html
+++ b/pages/exploremore.html
@@ -22,12 +22,16 @@
       <span class="navbar-text">Recode Hive</span>
     </a>
     <div class="navbar-right">
-      <a href="githubbadge.html" class="navbar-link">Github-Badge</a>
+      <a href="githubbadge.html" class="navbar-link">Github-Badges</a>
+      <a href="devtools.html" class="navbar-link">Useful Devtools</a>
+      <a href="#" class="navbar-link">Tools</a>
+
       <a href="https://github.com/recodehive/awesome-github-profiles/issues/new?assignees=&labels=%E2%9E%95+profile&projects=&template=add_profile.md&title=Add+Profile%3A+"
         class="navbar-link">Add Profile</a>
       <a href="events.html" class="navbar-link">Events</a>
       <a href="blog.html" class="navbar-link">Blog</a>
       <a href="compare.html" class="navbar-link">Compare</a>
+      <a href="../login.html" class="navbar-link">Login</a>
 
 
       <div class="toggle-switch">
@@ -47,7 +51,7 @@
     </div>
   </nav>
   <div class="mobile-menu" id="mobile-menu">
-    <a href="githubbadge.html" class="navbar-links">Github-Badge</a>
+    <a href="githubbadge.html" class="navbar-links">Github-Badges</a>
     <a href="events.html" class="navbar-links">Events</a>
     <a href="blog.html" class="navbar-links">Blog</a>
     <a href="https://github.com/recodehive/awesome-github-profiles/issues/new?assignees=&labels=%E2%9E%95+profile&projects=&template=add_profile.md&title=Add+Profile%3A+"

--- a/pages/faq.html
+++ b/pages/faq.html
@@ -27,12 +27,17 @@
         <span class="navbar-text">Recode Hive</span>
       </a>
       <div class="navbar-right">
-        <a href="githubbadge.html" class="navbar-link">Github-Badge</a>
+        <a href="githubbadge.html" class="navbar-link">Github-Badges</a>
+        <a href="devtools.html" class="navbar-link">Useful Devtools</a>
+        <a href="#" class="navbar-link">Tools</a>
+
         <a href="https://github.com/recodehive/awesome-github-profiles/issues/new?assignees=&labels=%E2%9E%95+profile&projects=&template=add_profile.md&title=Add+Profile%3A+" 
         class="navbar-link">Add Profile</a>
         <a href="events.html" class="navbar-link">Events</a>
         <a href="blog.html" class="navbar-link">Blog</a>
         <a href="compare.html" class="navbar-link">Compare</a>
+        <a href="../login.html" class="navbar-link">Login</a>
+
        
         <div class="toggle-switch">
           <input type="checkbox" id="theme-toggle">
@@ -51,7 +56,7 @@
       </div>
     </nav> 
     <div class="mobile-menu" id="mobile-menu">
-      <a href="githubbadge.html" class="navbar-links">Github-Badge</a>
+      <a href="githubbadge.html" class="navbar-links">Github-Badges</a>
       <a href="events.html" class="navbar-links">Events</a>
       <a href="blog.html" class="navbar-links">Blog</a>
       <a href="https://github.com/recodehive/awesome-github-profiles/issues/new?assignees=&labels=%E2%9E%95+profile&projects=&template=add_profile.md&title=Add+Profile%3A+" class="navbar-links">Add Profile</a>

--- a/pages/githubbadge.html
+++ b/pages/githubbadge.html
@@ -27,12 +27,17 @@
             <span class="navbar-text">Recode Hive</span>
         </a>
         <div class="navbar-right">
-            <a href="githubbadge.html" class="navbar-link">Github-Badge</a>
+            <a href="githubbadge.html" class="navbar-link">Github-Badges</a>
+            <a href="devtools.html" class="navbar-link">Useful Devtools</a>
+            <a href="#" class="navbar-link">Tools</a>
+
             <a href="https://github.com/recodehive/awesome-github-profiles/issues/new?assignees=&labels=%E2%9E%95+profile&projects=&template=add_profile.md&title=Add+Profile%3A+"
                 class="navbar-link">Add Profile</a>
             <a href="events.html" class="navbar-link">Events</a>
             <a href="blog.html" class="navbar-link">Blog</a>
             <a href="compare.html" class="navbar-link">Compare</a>
+            <a href="../login.html" class="navbar-link">Login</a>
+
 
 
             <div class="toggle-switch">
@@ -52,7 +57,7 @@
         </div>
     </nav>
     <div class="mobile-menu" id="mobile-menu">
-        <a href="#" class="navbar-links">Github-Badge</a>
+        <a href="#" class="navbar-links">Github-Badges</a>
         <a href="events.html" class="navbar-links">Events</a>
         <a href="blog.html" class="navbar-links">Blog</a>
         <a href="https://github.com/recodehive/awesome-github-profiles/issues/new?assignees=&labels=%E2%9E%95+profile&projects=&template=add_profile.md&title=Add+Profile%3A+"

--- a/pages/help.html
+++ b/pages/help.html
@@ -26,7 +26,10 @@
 			<span class="navbar-text">Recode Hive</span>
 		</a>
 		<div class="navbar-right">
-			<a href="githubbadge.html" class="navbar-link">Github-Badge</a>
+			<a href="githubbadge.html" class="navbar-link">Github-Badges</a>
+      <a href="devtools.html" class="navbar-link">Useful Devtools</a>
+      <a href="#" class="navbar-link">Tools</a>
+
 			<a href="https://github.com/recodehive/awesome-github-profiles/issues/new?assignees=&labels=%E2%9E%95+profile&projects=&template=add_profile.md&title=Add+Profile%3A+"
 				class="navbar-link">Add Profile</a>
 			<a href="events.html" class="navbar-link">Events</a>
@@ -52,7 +55,7 @@
 		</div>
 	</nav>
 	<div class="mobile-menu" id="mobile-menu">
-		<a href="githubbadge.html" class="navbar-links">Github-Badge</a>
+		<a href="githubbadge.html" class="navbar-links">Github-Badges</a>
 		<a href="events.html" class="navbar-links">Events</a>
 		<a href="blog.html" class="navbar-links">Blog</a>
 		<a href="https://github.com/recodehive/awesome-github-profiles/issues/new?assignees=&labels=%E2%9E%95+profile&projects=&template=add_profile.md&title=Add+Profile%3A+" class="navbar-links">Add Profile</a>

--- a/pages/saved-blogs.html
+++ b/pages/saved-blogs.html
@@ -25,12 +25,17 @@
           <span class="navbar-text">Recode Hive</span>
           <a class="navbar-left" style="color: #333 !important;text-decoration: none;" href="../index.html">
         <div class="navbar-right">
-          <a href="githubbadge.html" class="navbar-link">Github-Badge</a>
+          <a href="githubbadge.html" class="navbar-link">Github-Badges</a>
+          <a href="devtools.html" class="navbar-link">Useful Devtools</a>
+          <a href="#" class="navbar-link">Tools</a>
+
           <a href="https://github.com/recodehive/awesome-github-profiles/issues/new?assignees=&labels=%E2%9E%95+profile&projects=&template=add_profile.md&title=Add+Profile%3A+" 
           class="navbar-link">Add Profile</a>
           <a href="events.html" class="navbar-link">Events</a>
           <a href="blog.html" class="navbar-link">Blog</a>
           <a href="compare.html" class="navbar-link">Compare</a>
+          <a href="../login.html" class="navbar-link">Login</a>
+
   
          
           <div class="toggle-switch">
@@ -51,7 +56,7 @@
     </nav> 
     <div class="mobile-menu" id="mobile-menu">
       <a href="events.html" class="navbar-links">Events</a>
-      <a href="githubbadge.html" class="navbar-links">Github-Badge</a>
+      <a href="githubbadge.html" class="navbar-links">Github-Badges</a>
       <a href="blog.html" class="navbar-links">Blog</a>
       <a href="https://github.com/recodehive/awesome-github-profiles/issues/new?assignees=&labels=%E2%9E%95+profile&projects=&template=add_profile.md&title=Add+Profile%3A+" class="navbar-links">Add Profile</a>
       <div class="toggle-switch">

--- a/pages/testimonial.html
+++ b/pages/testimonial.html
@@ -26,12 +26,17 @@
       <span class="navbar-text">Recode Hive</span>
     </a>
     <div class="navbar-right">
-      <a href="githubbadge.html" class="navbar-link">Github-Badge</a>
+      <a href="githubbadge.html" class="navbar-link">Github-Badges</a>
+      <a href="devtools.html" class="navbar-link">Useful Devtools</a>
+      <a href="#" class="navbar-link">Tools</a>
+
       <a href="https://github.com/recodehive/awesome-github-profiles/issues/new?assignees=&labels=%E2%9E%95+profile&projects=&template=add_profile.md&title=Add+Profile%3A+" 
       class="navbar-link">Add Profile</a>
       <a href="events.html" class="navbar-link">Events</a>
       <a href="blog.html" class="navbar-link">Blog</a>
       <a href="compare.html" class="navbar-link">Compare</a>
+      <a href="../login.html" class="navbar-link">Login</a>
+
 
      
       <div class="toggle-switch">

--- a/pages/videos.html
+++ b/pages/videos.html
@@ -40,9 +40,10 @@
                 <span class="navbar-text">Recode Hive</span>
             </div>
             <div class="navbar-right">
-                <a href="pages/githubbadge.html" class="navbar-link"
-                    >Github-Badge</a
-                >
+                <a href="pages/githubbadge.html" class="navbar-link">Github-Badges</a>
+                <a href="devtools.html" class="navbar-link">Useful Devtools</a>
+                <a href="#" class="navbar-link">Tools</a>
+
                 <a
                     href="https://github.com/recodehive/awesome-github-profiles/issues/new?assignees=&labels=%E2%9E%95+profile&projects=&template=add_profile.md&title=Add+Profile%3A+"
                     class="navbar-link"


### PR DESCRIPTION
Fixes #1493

### Changes Made
- Added missing `Useful Devtools`, `Tools`, and `Login` nav links to all inner pages
- Fixed inconsistent label `Github-Badge` → `Github-Badges` across all pages
- Removed duplicate `Github-Badge` entry in `compare.html` mobile menu


